### PR TITLE
feat: proposal for workspace layout refactor

### DIFF
--- a/openspec/changes/refactor-workspace-layout/design.md
+++ b/openspec/changes/refactor-workspace-layout/design.md
@@ -128,6 +128,27 @@ spatial/
 
 The `python/spatial.rs` (206 lines) follows the same split pattern, keeping PyO3 wrappers adjacent to their Rust counterparts.
 
+### Testing Module Rename
+
+The `example_components.rs` module contains `TestComponent` used for testing the component infrastructure. This will be renamed to `testing.rs` and the Python bindings moved from `rscm._lib.core` to `rscm._lib.testing`:
+
+```rust
+// crates/rscm-core/src/testing.rs (renamed from example_components.rs)
+pub struct TestComponent { ... }
+pub struct TestComponentParameters { ... }
+
+// crates/rscm-core/src/python/testing.rs (renamed from example_component.rs)
+create_component_builder!(TestComponentBuilder, TestComponent, TestComponentParameters);
+
+#[pymodule]
+pub fn testing(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<TestComponentBuilder>()?;
+    Ok(())
+}
+```
+
+**Rationale:** Separating test utilities from core exports clarifies their purpose and keeps the `core` module focused on production types.
+
 ### Alternatives Considered
 
 1. **Multiple extension modules (rscm._core, rscm._two_layer):** Would complicate installation and require multiple maturin builds. Rejected for added complexity without clear benefit.

--- a/openspec/changes/refactor-workspace-layout/proposal.md
+++ b/openspec/changes/refactor-workspace-layout/proposal.md
@@ -27,6 +27,8 @@ The current flat workspace structure mixes the root PyO3 bindings crate with the
   - `spatial/four_box.rs` - `FourBoxGrid`, `FourBoxRegion`
   - `spatial/hemispheric.rs` - `HemisphericGrid`, `HemisphericRegion`
 - Split `python/spatial.rs` to mirror the Rust structure
+- Rename `example_components.rs` to `testing.rs`
+- Move `TestComponentBuilder` Python export from `rscm._lib.core` to `rscm._lib.testing`
 
 **Python Namespace Pattern:**
 - `rscm` package exports only core data structures (Model, ModelBuilder, Timeseries, TimeseriesCollection)

--- a/openspec/changes/refactor-workspace-layout/specs/workspace-structure/spec.md
+++ b/openspec/changes/refactor-workspace-layout/specs/workspace-structure/spec.md
@@ -76,6 +76,28 @@ The maturin build configuration SHALL point to the correct crate location within
 - **THEN** all crates in `crates/` MUST compile successfully
 - **AND** the rscm crate MUST link against all component crates
 
+### Requirement: Testing Module Location
+
+The `rscm-core` crate SHALL provide test utilities in a dedicated `testing` module, with Python bindings exported separately from core types.
+
+#### Scenario: Rust testing module
+
+- **WHEN** examining `crates/rscm-core/src/`
+- **THEN** it MUST include `testing.rs` (renamed from `example_components.rs`)
+- **AND** it MUST export `TestComponent` and `TestComponentParameters`
+
+#### Scenario: Python testing submodule
+
+- **WHEN** importing `TestComponentBuilder`
+- **THEN** it MUST be imported via `from rscm._lib.testing import TestComponentBuilder`
+- **AND** it MUST NOT be available from `rscm._lib.core`
+
+#### Scenario: Testing module registered in sys.modules
+
+- **WHEN** the `_lib` extension is loaded
+- **THEN** `rscm._lib.testing` MUST be accessible
+- **AND** it MUST contain `TestComponentBuilder`
+
 ### Requirement: Spatial Module Organisation
 
 The `rscm-core` crate SHALL organise spatial grid types into a `spatial/` subdirectory with separate files for each grid implementation.

--- a/openspec/changes/refactor-workspace-layout/tasks.md
+++ b/openspec/changes/refactor-workspace-layout/tasks.md
@@ -38,59 +38,72 @@ This change depends on the `dx` branch (improve-component-dx) being merged first
 - [ ] 4.5 Create `python/spatial/hemispheric.rs` with `PyHemisphericRegion`, `PyHemisphericGrid`
 - [ ] 4.6 Update `python/mod.rs` to use directory module
 
-## 5. Extract two_layer into separate crate
+## 5. Rename example_components to testing module
 
-- [ ] 5.1 Create `crates/rscm-two-layer/` directory structure
-- [ ] 5.2 Create `crates/rscm-two-layer/Cargo.toml`
-- [ ] 5.3 Move `two_layer.rs` to `crates/rscm-two-layer/src/component.rs`
-- [ ] 5.4 Create `crates/rscm-two-layer/src/lib.rs` exporting component
-- [ ] 5.5 Create `crates/rscm-two-layer/src/python/mod.rs` with PyO3 submodule
-- [ ] 5.6 Add `rscm-two-layer` to workspace dependencies
+- [ ] 5.1 Rename `crates/rscm-core/src/example_components.rs` to `testing.rs`
+- [ ] 5.2 Rename `crates/rscm-core/src/python/example_component.rs` to `testing.rs`
+- [ ] 5.3 Create `#[pymodule] testing` in `python/testing.rs`
+- [ ] 5.4 Update `crates/rscm-core/src/lib.rs` module declaration
+- [ ] 5.5 Update `crates/rscm-core/src/python/mod.rs` to register `testing` submodule
+- [ ] 5.6 Update `crates/rscm/src/python/mod.rs` to register `rscm._lib.testing`
+- [ ] 5.7 Update `tests/test_example_component.py` import to use `rscm._lib.testing`
+- [ ] 5.8 Update `python/rscm/_lib/core.pyi` to remove `TestComponentBuilder`
+- [ ] 5.9 Create `python/rscm/_lib/testing.pyi` with `TestComponentBuilder`
 
-## 6. Create rscm-magicc scaffold
+## 6. Extract two_layer into separate crate
 
-- [ ] 6.1 Create `crates/rscm-magicc/` directory structure
-- [ ] 6.2 Create `crates/rscm-magicc/Cargo.toml`
-- [ ] 6.3 Create `crates/rscm-magicc/src/lib.rs` with module declarations
-- [ ] 6.4 Create empty domain subdirectories (`chemistry/`, `forcing/`, `climate/`, `carbon/`)
-- [ ] 6.5 Create `crates/rscm-magicc/src/python/mod.rs` scaffold
+- [ ] 6.1 Create `crates/rscm-two-layer/` directory structure
+- [ ] 6.2 Create `crates/rscm-two-layer/Cargo.toml`
+- [ ] 6.3 Move `two_layer.rs` to `crates/rscm-two-layer/src/component.rs`
+- [ ] 6.4 Create `crates/rscm-two-layer/src/lib.rs` exporting component
+- [ ] 6.5 Create `crates/rscm-two-layer/src/python/mod.rs` with PyO3 submodule
+- [ ] 6.6 Add `rscm-two-layer` to workspace dependencies
 
-## 7. Update main rscm crate for submodule registration
+## 7. Create rscm-magicc scaffold
 
-- [ ] 7.1 Update `crates/rscm/Cargo.toml` dependencies
-- [ ] 7.2 Update `crates/rscm/src/lib.rs` to register two_layer submodule
-- [ ] 7.3 Update `crates/rscm/src/python/mod.rs` for new module structure
-- [ ] 7.4 Remove `TwoLayerComponentBuilder` from root exports
+- [ ] 7.1 Create `crates/rscm-magicc/` directory structure
+- [ ] 7.2 Create `crates/rscm-magicc/Cargo.toml`
+- [ ] 7.3 Create `crates/rscm-magicc/src/lib.rs` with module declarations
+- [ ] 7.4 Create empty domain subdirectories (`chemistry/`, `forcing/`, `climate/`, `carbon/`)
+- [ ] 7.5 Create `crates/rscm-magicc/src/python/mod.rs` scaffold
 
-## 8. Create Python namespace packages
+## 8. Update main rscm crate for submodule registration
 
-- [ ] 8.1 Create `python/rscm/two_layer/__init__.py`
-- [ ] 8.2 Create `python/rscm/magicc/__init__.py` (empty scaffold)
-- [ ] 8.3 Update `python/rscm/__init__.py` to remove `TwoLayerComponentBuilder`
-- [ ] 8.4 Update type stubs (`python/rscm/_lib/*.pyi`) for new structure
+- [ ] 8.1 Update `crates/rscm/Cargo.toml` dependencies
+- [ ] 8.2 Update `crates/rscm/src/lib.rs` to register two_layer and testing submodules
+- [ ] 8.3 Update `crates/rscm/src/python/mod.rs` for new module structure
+- [ ] 8.4 Remove `TwoLayerComponentBuilder` from root exports
 
-## 9. Update build configuration
+## 9. Create Python namespace packages
 
-- [ ] 9.1 Update `pyproject.toml` with `manifest-path = "crates/rscm/Cargo.toml"`
-- [ ] 9.2 Update `Makefile` if paths are hardcoded
-- [ ] 9.3 Update `.bumpversion.toml` file paths for new crate locations
+- [ ] 9.1 Create `python/rscm/two_layer/__init__.py`
+- [ ] 9.2 Create `python/rscm/magicc/__init__.py` (empty scaffold)
+- [ ] 9.3 Update `python/rscm/__init__.py` to remove `TwoLayerComponentBuilder`
+- [ ] 9.4 Update type stubs (`python/rscm/_lib/*.pyi`) for new structure
 
-## 10. Update documentation and tooling
+## 10. Update build configuration
 
-- [ ] 10.1 Update `CLAUDE.md` workspace structure section
-- [ ] 10.2 Update `openspec/project.md` architecture section
-- [ ] 10.3 Update README.md if it references directory structure
+- [ ] 10.1 Update `pyproject.toml` with `manifest-path = "crates/rscm/Cargo.toml"`
+- [ ] 10.2 Update `Makefile` if paths are hardcoded
+- [ ] 10.3 Update `.bumpversion.toml` file paths for new crate locations
 
-## 11. Testing and validation
+## 11. Update documentation and tooling
 
-- [ ] 11.1 Run `cargo build --workspace` and fix any path issues
-- [ ] 11.2 Run `cargo test --workspace` and fix any test failures
-- [ ] 11.3 Run `make build-dev` and verify Python extension builds
-- [ ] 11.4 Run `uv run pytest` and fix any import errors
-- [ ] 11.5 Verify `from rscm.two_layer import TwoLayerComponentBuilder` works
-- [ ] 11.6 Run `make lint` and fix any issues
-- [ ] 11.7 Run `make format` to ensure consistent formatting
+- [ ] 11.1 Update `CLAUDE.md` workspace structure section
+- [ ] 11.2 Update `openspec/project.md` architecture section
+- [ ] 11.3 Update README.md if it references directory structure
 
-## 12. Create changelog entry
+## 12. Testing and validation
 
-- [ ] 12.1 Create `changelog/XX.breaking.md` documenting import path change
+- [ ] 12.1 Run `cargo build --workspace` and fix any path issues
+- [ ] 12.2 Run `cargo test --workspace` and fix any test failures
+- [ ] 12.3 Run `make build-dev` and verify Python extension builds
+- [ ] 12.4 Run `uv run pytest` and fix any import errors
+- [ ] 12.5 Verify `from rscm.two_layer import TwoLayerComponentBuilder` works
+- [ ] 12.6 Verify `from rscm._lib.testing import TestComponentBuilder` works
+- [ ] 12.7 Run `make lint` and fix any issues
+- [ ] 12.8 Run `make format` to ensure consistent formatting
+
+## 13. Create changelog entry
+
+- [ ] 13.1 Create `changelog/XX.breaking.md` documenting import path changes


### PR DESCRIPTION
## Summary

- Adds OpenSpec change proposal for restructuring the repository workspace layout
- Moves all Rust crates into `crates/` subdirectory
- Splits `spatial.rs` (923 lines) into `spatial/` subdirectory module
- Extracts `two_layer` into separate `rscm-two-layer` crate
- Creates `rscm-magicc` scaffold with domain subdirectories
- Establishes Python namespace pattern (`rscm.two_layer`, `rscm.magicc`)

## Prerequisites

This change depends on the `dx` branch being merged first, as it introduces `rscm-macros/` which will be moved to `crates/rscm-macros/`.

## Files

- `openspec/changes/refactor-workspace-layout/proposal.md` - Why/what/impact
- `openspec/changes/refactor-workspace-layout/design.md` - Architectural decisions
- `openspec/changes/refactor-workspace-layout/tasks.md` - 12 task groups, 47 subtasks
- `openspec/changes/refactor-workspace-layout/specs/workspace-structure/spec.md` - 7 requirements with scenarios

## Test plan

- [x] `openspec validate refactor-workspace-layout --strict --no-interactive` passes
- [ ] Review proposal for completeness
- [ ] Approve before implementation begins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive workspace refactor design, proposal, specs, and task plans describing a move to a crates-based layout and a consolidated Python namespace with per-crate subpackages.
  * Documented migration steps, testing guidance, risks/rollback, and rollout considerations.
  * **Breaking Change**: Python import paths for model-specific components (e.g., TwoLayerComponentBuilder) will change as part of the refactor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->